### PR TITLE
Fix Docker tag format issue in GitHub Actions

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -49,7 +49,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Problem

Docker builds were failing with:
```
ERROR: invalid tag 'ghcr.io/jdubz/job-finder:-9018bc6': invalid reference format
```

## Root Cause

Line 52 in `.github/workflows/docker-build-push.yml` had:
```yaml
type=sha,prefix={{branch}}-
```

For PRs, `{{branch}}` was empty, resulting in invalid tags like `-9018bc6`.

## Fix

Changed to simple SHA tag:
```yaml
type=sha
```

This generates valid tags like `sha-9018bc6` instead.

## Impact

- ✅ Docker builds will succeed
- ✅ Images will be pushed to GitHub Container Registry
- ✅ Watchtower can update the production container

## Testing

Will verify build succeeds after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)