### PR TITLE
Fix Docker local testing setup with PYTHONPATH and credential paths

### DIFF
--- a/DOCKER_LOCAL_TESTING.md
+++ b/DOCKER_LOCAL_TESTING.md
@@ -1,0 +1,216 @@
+# Local Docker Testing Guide
+
+Two docker-compose files for local testing of the job-finder container.
+
+## Prerequisites
+
+```bash
+# Ensure your credentials are in place
+ls ~/.firebase/serviceAccountKey.json
+
+# Ensure environment variables are set
+echo $ANTHROPIC_API_KEY
+
+# Create logs directory if it doesn't exist
+mkdir -p logs data
+```
+
+## Option 1: Test Production Container (from ghcr.io)
+
+Tests the exact same container that's deployed in Portainer.
+
+```bash
+# Pull and run the production container
+docker-compose -f docker-compose.local-prod.yml up
+
+# In another terminal, exec into the running container
+docker exec -it job-finder-local-prod /bin/bash
+
+# Inside the container, test manually:
+python scheduler.py
+# or
+python run_job_search.py
+```
+
+### Run scheduler once and exit:
+```bash
+# Edit docker-compose.local-prod.yml and change the command to:
+# command: python scheduler.py
+
+docker-compose -f docker-compose.local-prod.yml up
+```
+
+### Test cron behavior:
+```bash
+# Edit docker-compose.local-prod.yml and change the command to:
+# command: /bin/bash -c "printenv > /etc/environment && cron && tail -f /var/log/cron.log"
+
+docker-compose -f docker-compose.local-prod.yml up
+```
+
+### View logs:
+```bash
+# Container logs
+docker-compose -f docker-compose.local-prod.yml logs -f
+
+# Scheduler logs (from mounted volume)
+tail -f logs/scheduler.log
+
+# Cron logs (inside container)
+docker exec job-finder-local-prod tail -f /var/log/cron.log
+```
+
+### Cleanup:
+```bash
+docker-compose -f docker-compose.local-prod.yml down
+```
+
+---
+
+## Option 2: Test Local Build
+
+Builds from your local Dockerfile and source code. Use this to test changes before pushing.
+
+```bash
+# Build and run from local source
+docker-compose -f docker-compose.local-build.yml up --build
+
+# In another terminal, exec into the running container
+docker exec -it job-finder-local-build /bin/bash
+
+# Inside the container, test manually:
+python scheduler.py
+# or
+python run_job_search.py
+```
+
+### Run scheduler once and exit:
+```bash
+# Edit docker-compose.local-build.yml and change the command to:
+# command: python scheduler.py
+
+docker-compose -f docker-compose.local-build.yml up --build
+```
+
+### Test cron behavior:
+```bash
+# Edit docker-compose.local-build.yml and change the command to:
+# command: /bin/bash -c "printenv > /etc/environment && cron && tail -f /var/log/cron.log"
+
+docker-compose -f docker-compose.local-build.yml up --build
+```
+
+### Rebuild after code changes:
+```bash
+docker-compose -f docker-compose.local-build.yml up --build --force-recreate
+```
+
+### Cleanup:
+```bash
+docker-compose -f docker-compose.local-build.yml down
+docker rmi job-finder:local  # Remove local image
+```
+
+---
+
+## Troubleshooting
+
+### Check if environment variables are passed correctly:
+```bash
+docker exec job-finder-local-prod env | grep -E 'ANTHROPIC|GOOGLE'
+```
+
+### Check if credentials file is mounted:
+```bash
+docker exec job-finder-local-prod ls -la /app/credentials/
+docker exec job-finder-local-prod cat /app/credentials/serviceAccountKey.json
+```
+
+### Check if config is mounted:
+```bash
+docker exec job-finder-local-prod cat /app/config/config.yaml
+```
+
+### Check if cron is running:
+```bash
+docker exec job-finder-local-prod ps aux | grep cron
+```
+
+### Check crontab is installed:
+```bash
+docker exec job-finder-local-prod crontab -l
+```
+
+### Manually trigger cron job:
+```bash
+docker exec job-finder-local-prod /bin/bash -c "cd /app && /usr/local/bin/python scheduler.py"
+```
+
+### Check Python path and imports:
+```bash
+docker exec job-finder-local-prod python -c "import sys; print(sys.path)"
+docker exec job-finder-local-prod python -c "from job_finder.search_orchestrator import JobSearchOrchestrator; print('OK')"
+```
+
+---
+
+## Common Issues
+
+### "Permission denied" on docker commands
+```bash
+# Activate docker group in current shell
+newgrp docker
+
+# Or log out and back in
+```
+
+### "serviceAccountKey.json not found"
+```bash
+# Adjust the volume mount path in the docker-compose file
+# Change: ~/.firebase:/app/credentials:ro
+# To your actual credentials path
+```
+
+### Environment variables not set
+```bash
+# Export them in your shell before running docker-compose
+export ANTHROPIC_API_KEY="your-key-here"
+
+# Or create a .env file in the project root
+cat > .env << 'EOF'
+ANTHROPIC_API_KEY=your-key-here
+OPENAI_API_KEY=your-key-here
+EOF
+```
+
+### Container exits immediately
+```bash
+# Check logs for errors
+docker-compose -f docker-compose.local-prod.yml logs
+
+# The default command keeps the container running for inspection
+# If it exits, there's likely a startup error
+```
+
+---
+
+## What's Different Between These Files?
+
+### docker-compose.local-prod.yml
+- Uses `image: ghcr.io/jdubz/job-finder:latest` (pulls from registry)
+- Tests the production container
+- Use this to debug Portainer deployment issues
+- Faster startup (no build)
+
+### docker-compose.local-build.yml
+- Uses `build: .` (builds from local Dockerfile)
+- Tests your local code changes
+- Use this before pushing to main
+- Slower startup (builds every time with --build)
+
+### docker-compose.yml (staging deployment)
+- Production-ready deployment file
+- Includes Watchtower for auto-updates
+- Resource limits configured
+- Healthchecks enabled
+- Use this in Portainer stacks

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod 0644 /etc/cron.d/job-finder-cron && \
 
 # Make PATH include user-installed packages
 ENV PATH=/root/.local/bin:$PATH
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/app/src:/app
 
 # Create data and logs directories
 RUN mkdir -p /app/data /app/logs

--- a/docker-compose.local-build.yml
+++ b/docker-compose.local-build.yml
@@ -1,0 +1,63 @@
+# Local BUILD and test (builds from local Dockerfile)
+# Usage: docker-compose -f docker-compose.local-build.yml up --build
+
+services:
+  job-finder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: job-finder:local
+    container_name: job-finder-local-build
+
+    environment:
+      # API Keys - will read from your shell environment
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/static-sites-257923-firebase-adminsdk.json
+
+      # Environment Configuration
+      - ENVIRONMENT=local-build-test
+
+      # Database Overrides - USE STAGING FOR LOCAL TESTING
+      - PROFILE_DATABASE_NAME=portfolio-staging
+      - STORAGE_DATABASE_NAME=portfolio-staging
+
+      # Config path
+      - CONFIG_PATH=/app/config/config.yaml
+      - LOG_FILE=/app/logs/scheduler.log
+
+      # Timezone
+      - TZ=America/Los_Angeles
+
+    volumes:
+      # Mount your local credentials (adjust path as needed)
+      - ./.firebase:/app/credentials:ro
+
+      # Mount local config
+      - ./config:/app/config:ro
+
+      # Mount logs directory for output
+      - ./logs:/app/logs
+
+      # Mount data directory
+      - ./data:/app/data
+
+    # Override the default CMD to keep container running for inspection
+    # Comment this out to run with default cron behavior
+    command: /bin/bash -c "printenv && echo '=== Container started ===' && tail -f /dev/null"
+
+    # Uncomment to run scheduler once and exit
+    # command: python scheduler.py
+
+    # Uncomment to test cron behavior
+    # command: /bin/bash -c "printenv > /etc/environment && cron && tail -f /var/log/cron.log"
+
+    networks:
+      - job-finder-local
+
+    stdin_open: true
+    tty: true
+
+networks:
+  job-finder-local:
+    driver: bridge

--- a/docker-compose.local-prod.yml
+++ b/docker-compose.local-prod.yml
@@ -1,0 +1,57 @@
+# Local testing of PRODUCTION container (pulled from ghcr.io)
+# Usage: docker-compose -f docker-compose.local-prod.yml up
+
+services:
+  job-finder:
+    image: ghcr.io/jdubz/job-finder:latest
+    container_name: job-finder-local-prod
+
+    environment:
+      # API Keys - will read from your shell environment
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/static-sites-257923-firebase-adminsdk.json
+
+      # Environment Configuration
+      - ENVIRONMENT=local-prod-test
+
+      # Database Overrides - USE STAGING FOR LOCAL TESTING
+      - PROFILE_DATABASE_NAME=portfolio-staging
+      - STORAGE_DATABASE_NAME=portfolio-staging
+
+      # Config path
+      - CONFIG_PATH=/app/config/config.yaml
+      - LOG_FILE=/app/logs/scheduler.log
+
+      # Timezone
+      - TZ=America/Los_Angeles
+
+    volumes:
+      # Mount your local credentials (adjust path as needed)
+      - ./.firebase:/app/credentials:ro
+
+      # Mount local config
+      - ./config:/app/config:ro
+
+      # Mount logs directory for output
+      - ./logs:/app/logs
+
+      # Mount data directory
+      - ./data:/app/data
+
+    # Override the default CMD to keep container running for inspection
+    # Comment this out to run with default cron behavior
+    command: /bin/bash -c "printenv && echo '=== Container started ===' && tail -f /dev/null"
+
+    # Uncomment to run scheduler once and exit
+    # command: python scheduler.py
+
+    networks:
+      - job-finder-local
+
+    stdin_open: true
+    tty: true
+
+networks:
+  job-finder-local:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Fix critical Python module import issues in Docker container
- Add comprehensive local testing infrastructure for Docker development
- Update credential mounting paths to match actual file locations

## Changes

### Dockerfile
- **Fix PYTHONPATH** to include `/app/src` for proper Python module resolution
  - Resolves `ModuleNotFoundError: No module named 'job_finder'`
  - Changed from `ENV PYTHONPATH=/app` to `ENV PYTHONPATH=/app/src:/app`

### New Docker Compose Files
- **docker-compose.local-build.yml** - Test local builds from Dockerfile before pushing
- **docker-compose.local-prod.yml** - Test production container from ghcr.io registry
- Both files configured with:
  - Correct Firebase credential paths (`./.firebase` instead of `~/.firebase`)
  - Actual credential filename (`static-sites-257923-firebase-adminsdk.json`)
  - Removed obsolete `version` attribute
  - Staging database configuration for safe local testing
  - Multiple command options (interactive shell, one-shot scheduler, cron testing)

### New Documentation
- **DOCKER_LOCAL_TESTING.md** - Comprehensive guide with:
  - Two testing workflows (local build vs production container)
  - Prerequisites checklist
  - Step-by-step usage instructions
  - Troubleshooting guide
  - Common issues and solutions

## Testing

Verified end-to-end functionality:
```bash
docker exec job-finder-local-build python scheduler.py
```

✅ Configuration loaded successfully
✅ Firestore connection established
✅ Profile loaded (6 experiences, 11 skills)
✅ AI matcher initialized
✅ RSS feed scraping working (51 jobs scraped)
✅ Filtering working (36 remote jobs)
✅ AI matching pipeline working (10 jobs processed)

All integrations verified:
- Python module imports
- Firestore/Firebase Admin SDK
- Anthropic Claude API
- RSS feed parsing
- Job filtering logic
- AI matching system

## Impact

This enables developers to:
1. Test Docker builds locally before pushing to production
2. Debug container issues with production images
3. Verify credential mounting and environment configuration
4. Test both one-shot and cron scheduling modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)