### PR TITLE
fix: detect and surface Google sign-in script load failures

### DIFF
--- a/job-finder-FE/src/App.tsx
+++ b/job-finder-FE/src/App.tsx
@@ -15,7 +15,12 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <GoogleOAuthProvider clientId={clientId}>
+      <GoogleOAuthProvider
+        clientId={clientId}
+        onScriptLoadError={() =>
+          console.error("Google Identity Services script failed to load — sign-in button will not render")
+        }
+      >
         <AuthProvider>
           <EntityModalProvider>
             <RestartOverlay />

--- a/job-finder-FE/src/components/auth/AuthModal.tsx
+++ b/job-finder-FE/src/components/auth/AuthModal.tsx
@@ -23,17 +23,22 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [scriptTimedOut, setScriptTimedOut] = useState(false)
 
-  // Detect when GIS script fails to load (it renders nothing silently)
+  // Detect when GIS script fails to load (it renders nothing silently).
+  // Only run while the modal is open and showing the Google Login button,
+  // since AuthModal stays mounted in Navigation even when closed.
   useEffect(() => {
+    if (!open || user || isDevelopment) {
+      setScriptTimedOut(false)
+      return
+    }
     if (scriptLoadedSuccessfully) {
       setScriptTimedOut(false)
       return
     }
-    const timer = setTimeout(() => {
-      if (!scriptLoadedSuccessfully) setScriptTimedOut(true)
-    }, 5000)
+    setScriptTimedOut(false)
+    const timer = setTimeout(() => setScriptTimedOut(true), 5000)
     return () => clearTimeout(timer)
-  }, [scriptLoadedSuccessfully, open])
+  }, [scriptLoadedSuccessfully, open, user, isDevelopment])
 
   const handleDevRoleSelect = (role: DevRole) => {
     setDevRole(role)
@@ -182,9 +187,14 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
                     </div>
 
                     {scriptTimedOut && (
-                      <div className="text-sm text-amber-700 dark:text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded p-3">
-                        <p className="font-medium mb-1">Google sign-in isn't loading</p>
-                        <p>This can happen if an ad blocker or browser privacy setting is blocking Google scripts. Try disabling your ad blocker for this site, or use a different browser.</p>
+                      <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                        <div className="flex items-start gap-2">
+                          <Info className="w-4 h-4 mt-0.5 text-amber-600 flex-shrink-0" />
+                          <div className="text-sm text-amber-700 dark:text-amber-400">
+                            <p className="font-medium mb-1">Google sign-in isn&apos;t loading</p>
+                            <p>This can happen if an ad blocker or browser privacy setting is blocking Google scripts. Try disabling your ad blocker for this site, or use a different browser.</p>
+                          </div>
+                        </div>
                       </div>
                     )}
 

--- a/job-finder-FE/src/components/auth/AuthModal.tsx
+++ b/job-finder-FE/src/components/auth/AuthModal.tsx
@@ -8,8 +8,8 @@ import {
 import { Button } from "@/components/ui/button"
 import { useAuth, type DevRole } from "@/contexts/AuthContext"
 import { LogOut, Shield, Info, User, Eye, Crown } from "lucide-react"
-import { useState } from "react"
-import { GoogleLogin } from "@react-oauth/google"
+import { useState, useEffect } from "react"
+import { GoogleLogin, useGoogleOAuth } from "@react-oauth/google"
 
 interface AuthModalProps {
   open: boolean
@@ -18,8 +18,22 @@ interface AuthModalProps {
 
 export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const { user, isOwner, signOut, loginWithGoogle, isDevelopment, setDevRole } = useAuth()
+  const { scriptLoadedSuccessfully } = useGoogleOAuth()
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [scriptTimedOut, setScriptTimedOut] = useState(false)
+
+  // Detect when GIS script fails to load (it renders nothing silently)
+  useEffect(() => {
+    if (scriptLoadedSuccessfully) {
+      setScriptTimedOut(false)
+      return
+    }
+    const timer = setTimeout(() => {
+      if (!scriptLoadedSuccessfully) setScriptTimedOut(true)
+    }, 5000)
+    return () => clearTimeout(timer)
+  }, [scriptLoadedSuccessfully, open])
 
   const handleDevRoleSelect = (role: DevRole) => {
     setDevRole(role)
@@ -166,6 +180,13 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
                         shape="rectangular"
                       />
                     </div>
+
+                    {scriptTimedOut && (
+                      <div className="text-sm text-amber-700 dark:text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded p-3">
+                        <p className="font-medium mb-1">Google sign-in isn't loading</p>
+                        <p>This can happen if an ad blocker or browser privacy setting is blocking Google scripts. Try disabling your ad blocker for this site, or use a different browser.</p>
+                      </div>
+                    )}
 
                     {isLoading && (
                       <div className="text-sm text-muted-foreground text-center">


### PR DESCRIPTION
The GoogleLogin component from @react-oauth/google silently renders nothing when the GIS script fails to load — no error, no feedback, just blank space where the button should be.

- Add onScriptLoadError to GoogleOAuthProvider so failures are logged
- Detect script load timeout in AuthModal via useGoogleOAuth() hook
- Show actionable fallback message after 5s suggesting ad blocker or browser privacy settings as the likely cause

## Summary
Explain what changed and why. Mention the workspace(s) this touches (FE, API/server, Firebase functions, worker, shared types, infra, docs, etc.).

## Testing
Check everything you ran (or remove items that do not apply).
- [ ] `npm run lint:server`
- [ ] `npm run lint:functions`
- [ ] `npm run lint:frontend`
- [ ] `npm run build:server`
- [ ] `npm run build:frontend`
- [ ] Workspace-specific unit tests (`npm test --workspace ...`, `pytest`, etc.)
- [ ] Other (describe below)

## Checklist
- [ ] Added/updated docs, env samples, or SQL migrations if needed
- [ ] Added/updated types in `shared/` if API/worker contracts changed
- [ ] Verified relevant Husky hooks still pass locally
- [ ] Confirmed no secrets or personal data are committed

## Screenshots / Logs
Attach screenshots, terminal output, or logs if they help reviewers.

## Additional Notes
Anything else reviewers should know (rollout steps, follow-ups, blockers, related issues).
