### PR TITLE
fix: replace iframe GoogleLogin with popup-based useGoogleLogin

### DIFF
--- a/job-finder-BE/server/src/config/google-oauth.ts
+++ b/job-finder-BE/server/src/config/google-oauth.ts
@@ -43,6 +43,45 @@ export async function verifyGoogleIdToken(token: string): Promise<GoogleUser | n
   }
 }
 
+/**
+ * Verify a Google OAuth access token via Google's tokeninfo endpoint.
+ * Used when the frontend authenticates via useGoogleLogin (popup flow)
+ * instead of the iframe-based GoogleLogin component.
+ */
+export async function verifyGoogleAccessToken(accessToken: string): Promise<GoogleUser | null> {
+  const oauthClient = getClient()
+  if (!oauthClient) {
+    return null
+  }
+  try {
+    const tokenInfo = await oauthClient.getTokenInfo(accessToken)
+
+    if (!tokenInfo.email) {
+      logger.warn("Google access token missing email scope")
+      return null
+    }
+
+    // Fetch full profile (name, picture) from userinfo endpoint
+    const userinfoRes = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    const profile = userinfoRes.ok
+      ? (await userinfoRes.json()) as { sub?: string; name?: string; picture?: string }
+      : {}
+
+    return {
+      uid: tokenInfo.sub ?? profile.sub ?? "",
+      email: tokenInfo.email,
+      emailVerified: tokenInfo.email_verified ?? undefined,
+      name: profile.name,
+      picture: profile.picture,
+    }
+  } catch (error) {
+    logger.warn({ err: error }, "Failed to verify Google access token")
+    return null
+  }
+}
+
 function mapPayload(payload: TokenPayload): GoogleUser {
   return {
     uid: payload.sub ?? "",

--- a/job-finder-BE/server/src/config/google-oauth.ts
+++ b/job-finder-BE/server/src/config/google-oauth.ts
@@ -68,6 +68,7 @@ export async function verifyGoogleAccessToken(accessToken: string): Promise<Goog
     // Fetch full profile (name, picture, and email fallback) from userinfo endpoint
     const userinfoRes = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
       headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(5000),
     })
     const profile = userinfoRes.ok
       ? (await userinfoRes.json()) as {

--- a/job-finder-BE/server/src/config/google-oauth.ts
+++ b/job-finder-BE/server/src/config/google-oauth.ts
@@ -56,23 +56,41 @@ export async function verifyGoogleAccessToken(accessToken: string): Promise<Goog
   try {
     const tokenInfo = await oauthClient.getTokenInfo(accessToken)
 
-    if (!tokenInfo.email) {
-      logger.warn("Google access token missing email scope")
+    // Reject tokens minted for a different OAuth client
+    if (env.GOOGLE_OAUTH_CLIENT_ID && tokenInfo.aud !== env.GOOGLE_OAUTH_CLIENT_ID) {
+      logger.warn(
+        { expected: env.GOOGLE_OAUTH_CLIENT_ID, got: tokenInfo.aud },
+        "Google access token audience mismatch"
+      )
       return null
     }
 
-    // Fetch full profile (name, picture) from userinfo endpoint
+    // Fetch full profile (name, picture, and email fallback) from userinfo endpoint
     const userinfoRes = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
       headers: { Authorization: `Bearer ${accessToken}` },
     })
     const profile = userinfoRes.ok
-      ? (await userinfoRes.json()) as { sub?: string; name?: string; picture?: string }
+      ? (await userinfoRes.json()) as {
+          sub?: string
+          email?: string
+          email_verified?: boolean
+          name?: string
+          picture?: string
+        }
       : {}
+
+    const email = tokenInfo.email ?? profile.email
+    const emailVerified = tokenInfo.email_verified ?? profile.email_verified ?? undefined
+
+    if (!email) {
+      logger.warn("Google access token missing email scope")
+      return null
+    }
 
     return {
       uid: tokenInfo.sub ?? profile.sub ?? "",
-      email: tokenInfo.email,
-      emailVerified: tokenInfo.email_verified ?? undefined,
+      email,
+      emailVerified,
       name: profile.name,
       picture: profile.picture,
     }

--- a/job-finder-BE/server/src/routes/__tests__/auth.routes.test.ts
+++ b/job-finder-BE/server/src/routes/__tests__/auth.routes.test.ts
@@ -150,7 +150,7 @@ describe('POST /auth/login', () => {
     getDb().prepare('DELETE FROM user_sessions').run()
   })
 
-  it('routes JWT credentials (3 dot-separated segments) to ID token verification', async () => {
+  it('succeeds when ID token verification passes', async () => {
     const fakeJwt = 'header.payload.signature'
     mockedVerifyIdToken.mockResolvedValueOnce({
       uid: 'google-123',
@@ -164,13 +164,15 @@ describe('POST /auth/login', () => {
       .send({ credential: fakeJwt })
 
     expect(mockedVerifyIdToken).toHaveBeenCalledWith(fakeJwt)
-    expect(mockedVerifyAccessToken).not.toHaveBeenCalled()
     expect(res.status).toBe(200)
     expect(res.body.data.user.email).toBe('jwt@test.dev')
   })
 
-  it('routes opaque credentials (no dots) to access token verification', async () => {
-    const accessToken = 'ya29_opaque_access_token_no_dots'
+  it('falls back to access token verification when ID token returns null', async () => {
+    const accessToken = 'ya29_opaque_access_token'
+    // ID token verification fails (not a JWT)
+    mockedVerifyIdToken.mockResolvedValueOnce(null)
+    // Access token verification succeeds
     mockedVerifyAccessToken.mockResolvedValueOnce({
       uid: 'google-456',
       email: 'access@test.dev',
@@ -182,18 +184,19 @@ describe('POST /auth/login', () => {
       .post('/auth/login')
       .send({ credential: accessToken })
 
+    expect(mockedVerifyIdToken).toHaveBeenCalledWith(accessToken)
     expect(mockedVerifyAccessToken).toHaveBeenCalledWith(accessToken)
-    expect(mockedVerifyIdToken).not.toHaveBeenCalled()
     expect(res.status).toBe(200)
     expect(res.body.data.user.email).toBe('access@test.dev')
   })
 
-  it('returns 401 when access token verification fails', async () => {
+  it('returns 401 when both verification methods fail', async () => {
+    mockedVerifyIdToken.mockResolvedValueOnce(null)
     mockedVerifyAccessToken.mockResolvedValueOnce(null)
 
     const res = await request(app)
       .post('/auth/login')
-      .send({ credential: 'invalid_access_token' })
+      .send({ credential: 'invalid_token' })
 
     expect(res.status).toBe(401)
     expect(res.body.error.code).toBe(ApiErrorCode.INVALID_TOKEN)

--- a/job-finder-BE/server/src/routes/__tests__/auth.routes.test.ts
+++ b/job-finder-BE/server/src/routes/__tests__/auth.routes.test.ts
@@ -1,12 +1,27 @@
 import express from 'express'
 import request from 'supertest'
-import { describe, expect, it, beforeEach } from 'vitest'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { buildAuthRouter } from '../auth.routes'
 import { apiErrorHandler } from '../../middleware/api-error'
 import { ApiErrorCode } from '@shared/types'
 import { UserRepository } from '../../modules/users/user.repository'
 import { getDb } from '../../db/sqlite'
 import { serialize as serializeCookie } from 'cookie'
+
+// Mock Google OAuth verification — real Google APIs aren't available in tests
+vi.mock('../../config/google-oauth', async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal()
+  return {
+    ...actual,
+    verifyGoogleIdToken: vi.fn().mockResolvedValue(null),
+    verifyGoogleAccessToken: vi.fn().mockResolvedValue(null),
+  }
+})
+
+import { verifyGoogleIdToken, verifyGoogleAccessToken } from '../../config/google-oauth'
+
+const mockedVerifyIdToken = vi.mocked(verifyGoogleIdToken)
+const mockedVerifyAccessToken = vi.mocked(verifyGoogleAccessToken)
 
 const userRepo = new UserRepository()
 
@@ -111,5 +126,93 @@ describe('GET /auth/session', () => {
     expect(user.uid).toBeDefined()
     expect(user.name).toBe('Test User')
     expect(user.email).toBe('fields@test.dev')
+  })
+
+  it('clears the session cookie when returning 401 for invalid token', async () => {
+    const cookie = serializeCookie('jf_session', 'stale-token')
+    const res = await request(app)
+      .get('/auth/session')
+      .set('Cookie', cookie)
+
+    expect(res.status).toBe(401)
+    // Server should send Set-Cookie to expire the stale cookie
+    const setCookie = res.headers['set-cookie']
+    expect(setCookie).toBeDefined()
+    expect(setCookie.toString()).toMatch(/jf_session=;/)
+  })
+})
+
+describe('POST /auth/login', () => {
+  const app = buildTestApp()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getDb().prepare('DELETE FROM user_sessions').run()
+  })
+
+  it('routes JWT credentials (3 dot-separated segments) to ID token verification', async () => {
+    const fakeJwt = 'header.payload.signature'
+    mockedVerifyIdToken.mockResolvedValueOnce({
+      uid: 'google-123',
+      email: 'jwt@test.dev',
+      name: 'JWT User',
+      picture: 'https://photo.test/jwt.jpg',
+    })
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ credential: fakeJwt })
+
+    expect(mockedVerifyIdToken).toHaveBeenCalledWith(fakeJwt)
+    expect(mockedVerifyAccessToken).not.toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(res.body.data.user.email).toBe('jwt@test.dev')
+  })
+
+  it('routes opaque credentials (no dots) to access token verification', async () => {
+    const accessToken = 'ya29_opaque_access_token_no_dots'
+    mockedVerifyAccessToken.mockResolvedValueOnce({
+      uid: 'google-456',
+      email: 'access@test.dev',
+      name: 'Access User',
+      picture: 'https://photo.test/access.jpg',
+    })
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ credential: accessToken })
+
+    expect(mockedVerifyAccessToken).toHaveBeenCalledWith(accessToken)
+    expect(mockedVerifyIdToken).not.toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(res.body.data.user.email).toBe('access@test.dev')
+  })
+
+  it('returns 401 when access token verification fails', async () => {
+    mockedVerifyAccessToken.mockResolvedValueOnce(null)
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ credential: 'invalid_access_token' })
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe(ApiErrorCode.INVALID_TOKEN)
+  })
+
+  it('sets session cookie on successful login', async () => {
+    mockedVerifyAccessToken.mockResolvedValueOnce({
+      uid: 'google-789',
+      email: 'cookie@test.dev',
+      name: 'Cookie User',
+    })
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ credential: 'valid_access_token' })
+
+    expect(res.status).toBe(200)
+    const setCookie = res.headers['set-cookie']
+    expect(setCookie).toBeDefined()
+    expect(setCookie.toString()).toMatch(/jf_session=/)
   })
 })

--- a/job-finder-BE/server/src/routes/auth.routes.ts
+++ b/job-finder-BE/server/src/routes/auth.routes.ts
@@ -2,7 +2,7 @@ import { Router, type Request, type Response, type RequestHandler, type NextFunc
 import { parse as parseCookie } from 'cookie'
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
-import { verifyGoogleIdToken } from '../config/google-oauth'
+import { verifyGoogleIdToken, verifyGoogleAccessToken } from '../config/google-oauth'
 import { success } from '../utils/api-response'
 import { env } from '../config/env'
 import { DEV_TOKENS } from '../config/dev-tokens'
@@ -97,8 +97,14 @@ export function buildAuthRouter() {
       )
     }
 
-    // Production: validate Google OAuth credential
-    const googleUser = await verifyGoogleIdToken(credential)
+    // Production: validate Google OAuth credential.
+    // Try ID token (JWT from GoogleLogin component) first, then access token
+    // (opaque string from useGoogleLogin popup flow).
+    const isJwt = credential.split('.').length === 3
+    const googleUser = isJwt
+      ? await verifyGoogleIdToken(credential)
+      : await verifyGoogleAccessToken(credential)
+
     if (!googleUser || !googleUser.email) {
       throw new ApiHttpError(ApiErrorCode.INVALID_TOKEN, 'Invalid Google credential', {
         status: 401,

--- a/job-finder-BE/server/src/routes/auth.routes.ts
+++ b/job-finder-BE/server/src/routes/auth.routes.ts
@@ -98,12 +98,11 @@ export function buildAuthRouter() {
     }
 
     // Production: validate Google OAuth credential.
-    // Try ID token (JWT from GoogleLogin component) first, then access token
-    // (opaque string from useGoogleLogin popup flow).
-    const isJwt = credential.split('.').length === 3
-    const googleUser = isJwt
-      ? await verifyGoogleIdToken(credential)
-      : await verifyGoogleAccessToken(credential)
+    // Try ID token first, fall back to access token. This avoids brittle
+    // format detection — verifyGoogleIdToken returns null fast for non-JWTs.
+    const googleUser =
+      await verifyGoogleIdToken(credential) ??
+      await verifyGoogleAccessToken(credential)
 
     if (!googleUser || !googleUser.email) {
       throw new ApiHttpError(ApiErrorCode.INVALID_TOKEN, 'Invalid Google credential', {

--- a/job-finder-FE/e2e/oauth-authentication.spec.ts
+++ b/job-finder-FE/e2e/oauth-authentication.spec.ts
@@ -10,62 +10,66 @@ test.describe('Google OAuth Authentication Flow', () => {
     // No init script needed - we want empty localStorage for these tests
   })
 
-  // Skip this test - Google OAuth doesn't work in test environment without real client ID
-  test.skip('sign in modal appears when clicking sign in button', async ({ page }) => {
+  test('sign in modal renders with interactive content', async ({ page }) => {
     await page.goto(ROUTES.HOME, { waitUntil: 'domcontentloaded' })
 
-    // Find and click the sign in button
-    const signInButton = page.getByRole('button', { name: /sign in|log in/i }).first()
-    await expect(signInButton).toBeVisible({ timeout: 10000 })
-    await signInButton.click()
+    const authModal = await openAuthModal(page, 'anonymous')
 
-    // Modal should appear
-    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 })
+    // In dev mode: role selector buttons should be visible (not blank)
+    // In prod mode: "Continue with Google" button should be visible
+    // Either way, the modal must have interactive content — not a blank screen
+    const hasDevButtons = await authModal.getByRole('button', { name: /Admin/i }).isVisible().catch(() => false)
+    const hasGoogleButton = await authModal.getByRole('button', { name: /Continue with Google/i }).isVisible().catch(() => false)
 
-    // Google Sign In button should be present
-    await expect(page.getByText(/continue with google|sign in with google/i).first()).toBeVisible({ timeout: 10000 })
+    expect(hasDevButtons || hasGoogleButton).toBe(true)
   })
 
-  // Skip this test - requires OAuth modal which won't work in test environment
-  test.skip('sign in modal can be closed', async ({ page }) => {
-    await page.goto(ROUTES.HOME)
+  test('sign in modal can be closed with Escape', async ({ page }) => {
+    await page.goto(ROUTES.HOME, { waitUntil: 'domcontentloaded' })
 
-    const signInButton = page.getByRole('button', { name: /sign in|log in/i }).first()
-    if (await signInButton.isVisible()) {
-      await signInButton.click()
+    const modal = await openAuthModal(page, 'anonymous')
+    await expect(modal).toBeVisible()
 
-      const modal = page.getByRole('dialog')
-      await expect(modal).toBeVisible({ timeout: 5000 })
-
-      // Close modal (look for X button or close button)
-      const closeButton = page.getByRole('button', { name: /close/i }).first()
-      if (await closeButton.isVisible()) {
-        await closeButton.click()
-        await expect(modal).not.toBeVisible()
-      } else {
-        // Try ESC key
-        await page.keyboard.press('Escape')
-        await expect(modal).not.toBeVisible()
-      }
-    }
+    await page.keyboard.press('Escape')
+    await expect(modal).not.toBeVisible()
   })
 
-  // Skip this test - requires OAuth modal which won't work in test environment
-  test.skip('sign in modal appears when trying to access admin page while unauthenticated', async ({ page }) => {
-    await page.goto(ROUTES.AI_PROMPTS, { waitUntil: 'domcontentloaded' })
+  test('session endpoint returns 200 with user: null on cold load (no cookie)', async ({ page }) => {
+    // Intercept the session API call that AuthContext makes on mount
+    const sessionResponsePromise = page.waitForResponse(
+      (res) => res.url().includes('/auth/session') && res.request().method() === 'GET'
+    )
 
-    // Should be on unauthorized page
-    await expect(page).toHaveURL(ROUTES.UNAUTHORIZED, { timeout: 10000 })
+    await page.goto(ROUTES.HOME, { waitUntil: 'domcontentloaded' })
 
-    // Should have a sign in button/link
-    const signInButton = page.getByRole('button', { name: /sign in|log in/i }).first()
-    if (await signInButton.isVisible({ timeout: 10000 }).catch(() => false)) {
-      await signInButton.click()
+    const sessionResponse = await sessionResponsePromise
+    expect(sessionResponse.status()).toBe(200)
 
-      // Modal should appear
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 })
-      await expect(page.getByText(/continue with google|sign in with google/i).first()).toBeVisible({ timeout: 10000 })
-    }
+    const body = await sessionResponse.json()
+    expect(body.success).toBe(true)
+    expect(body.data.user).toBeNull()
+  })
+
+  test('session endpoint returns 200 with user data after login', async ({ context }) => {
+    await loginWithDevToken(context, 'dev-admin-token')
+    const page = await context.newPage()
+
+    const sessionResponsePromise = page.waitForResponse(
+      (res) => res.url().includes('/auth/session') && res.request().method() === 'GET'
+    )
+
+    await page.goto(ROUTES.HOME, { waitUntil: 'domcontentloaded' })
+
+    const sessionResponse = await sessionResponsePromise
+    expect(sessionResponse.status()).toBe(200)
+
+    const body = await sessionResponse.json()
+    expect(body.success).toBe(true)
+    expect(body.data.user).toBeTruthy()
+    expect(body.data.user.email).toBeDefined()
+    expect(body.data.user.roles).toBeDefined()
+
+    await page.close()
   })
 
   test('successful authentication with viewer email redirects correctly', async ({ context }) => {
@@ -178,20 +182,4 @@ test.describe('Google OAuth Authentication Flow', () => {
     await page.close()
   })
 
-  // These tests are no longer relevant with proper backend session auth
-  // The backend validates sessions, not localStorage tokens
-
-  // Skip this test - requires Google OAuth button which won't work in test environment
-  test.skip('Google Sign In button uses correct branding', async ({ page }) => {
-    await page.goto(ROUTES.HOME)
-
-    const signInButton = page.getByRole('button', { name: /sign in|log in/i }).first()
-    if (await signInButton.isVisible()) {
-      await signInButton.click()
-
-      // Should see Google-branded button
-      const googleButton = page.locator('[role="button"]', { hasText: /continue with google|sign in with google/i })
-      await expect(googleButton.first()).toBeVisible({ timeout: 5000 })
-    }
-  })
 })

--- a/job-finder-FE/src/App.tsx
+++ b/job-finder-FE/src/App.tsx
@@ -15,12 +15,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <GoogleOAuthProvider
-        clientId={clientId}
-        onScriptLoadError={() =>
-          console.error("Google Identity Services script failed to load — sign-in button will not render")
-        }
-      >
+      <GoogleOAuthProvider clientId={clientId}>
         <AuthProvider>
           <EntityModalProvider>
             <RestartOverlay />

--- a/job-finder-FE/src/App.tsx
+++ b/job-finder-FE/src/App.tsx
@@ -15,7 +15,12 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <GoogleOAuthProvider clientId={clientId}>
+      <GoogleOAuthProvider
+        clientId={clientId}
+        onScriptLoadError={() =>
+          console.error("Google Identity Services script failed to load")
+        }
+      >
         <AuthProvider>
           <EntityModalProvider>
             <RestartOverlay />

--- a/job-finder-FE/src/components/auth/AuthModal.tsx
+++ b/job-finder-FE/src/components/auth/AuthModal.tsx
@@ -8,8 +8,8 @@ import {
 import { Button } from "@/components/ui/button"
 import { useAuth, type DevRole } from "@/contexts/AuthContext"
 import { LogOut, Shield, Info, User, Eye, Crown } from "lucide-react"
-import { useState, useEffect } from "react"
-import { GoogleLogin, useGoogleOAuth } from "@react-oauth/google"
+import { useState } from "react"
+import { useGoogleLogin } from "@react-oauth/google"
 
 interface AuthModalProps {
   open: boolean
@@ -18,27 +18,27 @@ interface AuthModalProps {
 
 export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const { user, isOwner, signOut, loginWithGoogle, isDevelopment, setDevRole } = useAuth()
-  const { scriptLoadedSuccessfully } = useGoogleOAuth()
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [scriptTimedOut, setScriptTimedOut] = useState(false)
 
-  // Detect when GIS script fails to load (it renders nothing silently).
-  // Only run while the modal is open and showing the Google Login button,
-  // since AuthModal stays mounted in Navigation even when closed.
-  useEffect(() => {
-    if (!open || user || isDevelopment) {
-      setScriptTimedOut(false)
-      return
-    }
-    if (scriptLoadedSuccessfully) {
-      setScriptTimedOut(false)
-      return
-    }
-    setScriptTimedOut(false)
-    const timer = setTimeout(() => setScriptTimedOut(true), 5000)
-    return () => clearTimeout(timer)
-  }, [scriptLoadedSuccessfully, open, user, isDevelopment])
+  // Use the popup-based OAuth flow instead of the iframe-based GoogleLogin
+  // component. The iframe approach broke after Google's mandatory FedCM
+  // migration (August 2025) — the button silently fails to render.
+  // The popup flow opens accounts.google.com directly and returns an
+  // access token which the backend validates via Google's tokeninfo API.
+  const googleLogin = useGoogleLogin({
+    onSuccess: (response) => handleGoogleLogin(response.access_token),
+    onError: (errorResponse) => {
+      console.error("Google login error:", errorResponse)
+      setError("Failed to sign in with Google. Please try again.")
+    },
+    onNonOAuthError: (errorResponse) => {
+      // Popup closed, blocked, etc — don't show error for intentional cancellation
+      if (errorResponse.type === "popup_failed_to_open") {
+        setError("Popup was blocked. Please allow popups for this site.")
+      }
+    },
+  })
 
   const handleDevRoleSelect = (role: DevRole) => {
     setDevRole(role)
@@ -168,41 +168,21 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
                   </div>
 
                   <div className="space-y-3">
-                    <div className="flex justify-center">
-                      <GoogleLogin
-                        onSuccess={(response) => {
-                          if (response.credential) {
-                            handleGoogleLogin(response.credential)
-                          } else {
-                            setError("Missing credential from Google. Please try again.")
-                          }
-                        }}
-                        onError={() => setError("Failed to sign in. Please try again.")}
-                        useOneTap={false}
-                        size="large"
-                        theme="outline"
-                        text="continue_with"
-                        shape="rectangular"
-                      />
-                    </div>
-
-                    {scriptTimedOut && (
-                      <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
-                        <div className="flex items-start gap-2">
-                          <Info className="w-4 h-4 mt-0.5 text-amber-600 flex-shrink-0" />
-                          <div className="text-sm text-amber-700 dark:text-amber-400">
-                            <p className="font-medium mb-1">Google sign-in isn&apos;t loading</p>
-                            <p>This can happen if an ad blocker or browser privacy setting is blocking Google scripts. Try disabling your ad blocker for this site, or use a different browser.</p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {isLoading && (
-                      <div className="text-sm text-muted-foreground text-center">
-                        Signing in...
-                      </div>
-                    )}
+                    <Button
+                      onClick={() => googleLogin()}
+                      variant="outline"
+                      className="w-full"
+                      size="lg"
+                      disabled={isLoading}
+                    >
+                      <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
+                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                      </svg>
+                      {isLoading ? "Signing in..." : "Continue with Google"}
+                    </Button>
 
                     {error && (
                       <div className="text-sm text-destructive bg-destructive/10 rounded p-3">

--- a/job-finder-FE/src/contexts/__tests__/AuthContext.test.tsx
+++ b/job-finder-FE/src/contexts/__tests__/AuthContext.test.tsx
@@ -101,6 +101,38 @@ describe("AuthContext", () => {
     })
   })
 
+  it("treats fetchSession error as logged out without crashing", async () => {
+    vi.mocked(authClient.fetchSession).mockRejectedValueOnce(new Error("Network error"))
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    // Should settle to unauthenticated state, not crash
+    await waitFor(() => {
+      expect(screen.getByTestId("user-email")).toHaveTextContent("No user")
+      expect(screen.getByTestId("is-owner")).toHaveTextContent("Viewer")
+    })
+  })
+
+  it("treats 401 session error as logged out without crashing", async () => {
+    const apiError = new Error("Invalid or expired session")
+    Object.assign(apiError, { statusCode: 401, name: "ApiError" })
+    vi.mocked(authClient.fetchSession).mockRejectedValueOnce(apiError)
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user-email")).toHaveTextContent("No user")
+    })
+  })
+
   it("clears state on sign out", async () => {
     render(
       <AuthProvider>


### PR DESCRIPTION
Google's mandatory FedCM migration (August 2025) broke the iframe-based GoogleLogin button — it silently renders nothing. No error, no fallback, just blank space where the button should be.

Switch to useGoogleLogin hook which opens the OAuth popup directly via google.accounts.oauth2 (no iframe/FedCM dependency). This gives us a custom button we fully control.

Backend: The popup flow returns an access token instead of a JWT ID token. Added verifyGoogleAccessToken() that validates via Google's tokeninfo + userinfo APIs. The login handler auto-detects token type (JWT = ID token, opaque = access token) so both flows work.

Frontend: Custom "Continue with Google" button replaces the Google iframe. Uses useGoogleLogin with implicit flow. Proper error handling for popup blocked/failed scenarios.

## Summary
Explain what changed and why. Mention the workspace(s) this touches (FE, API/server, Firebase functions, worker, shared types, infra, docs, etc.).

## Testing
Check everything you ran (or remove items that do not apply).
- [ ] `npm run lint:server`
- [ ] `npm run lint:functions`
- [ ] `npm run lint:frontend`
- [ ] `npm run build:server`
- [ ] `npm run build:frontend`
- [ ] Workspace-specific unit tests (`npm test --workspace ...`, `pytest`, etc.)
- [ ] Other (describe below)

## Checklist
- [ ] Added/updated docs, env samples, or SQL migrations if needed
- [ ] Added/updated types in `shared/` if API/worker contracts changed
- [ ] Verified relevant Husky hooks still pass locally
- [ ] Confirmed no secrets or personal data are committed

## Screenshots / Logs
Attach screenshots, terminal output, or logs if they help reviewers.

## Additional Notes
Anything else reviewers should know (rollout steps, follow-ups, blockers, related issues).
