### PR TITLE
fix: revert to GoogleLogin component — useGoogleLogin popup is broken

### DIFF
--- a/job-finder-FE/src/components/auth/AuthModal.tsx
+++ b/job-finder-FE/src/components/auth/AuthModal.tsx
@@ -7,9 +7,9 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { useAuth, type DevRole } from "@/contexts/AuthContext"
-import { LogOut, Shield, Info, User, Eye, Crown, Loader2 } from "lucide-react"
+import { LogOut, Shield, Info, User, Eye, Crown } from "lucide-react"
 import { useState, useEffect } from "react"
-import { GoogleLogin, useGoogleOAuth } from "@react-oauth/google"
+import { GoogleLogin } from "@react-oauth/google"
 
 interface AuthModalProps {
   open: boolean
@@ -18,28 +18,21 @@ interface AuthModalProps {
 
 export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const { user, isOwner, signOut, loginWithGoogle, isDevelopment, setDevRole } = useAuth()
-  const { scriptLoadedSuccessfully } = useGoogleOAuth()
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [buttonTimedOut, setButtonTimedOut] = useState(false)
 
-  // The GoogleLogin component renders a button inside an iframe from Google.
-  // If the iframe fails to render (script blocked, FedCM issue), the space is
-  // blank with no error. Detect this and show an actionable message.
+  // If the Google sign-in button never becomes visible (script blocked, iframe
+  // fails to render), show an actionable fallback after 5s. Suppress the
+  // warning while a login is actively in progress.
   useEffect(() => {
-    if (!open || user || isDevelopment) {
+    if (!open || user || isDevelopment || isLoading) {
       setButtonTimedOut(false)
       return
     }
-    if (scriptLoadedSuccessfully) {
-      // Script loaded but button might still fail to render — give it time
-      const timer = setTimeout(() => setButtonTimedOut(true), 5000)
-      return () => clearTimeout(timer)
-    }
-    // Script itself didn't load
     const timer = setTimeout(() => setButtonTimedOut(true), 5000)
     return () => clearTimeout(timer)
-  }, [scriptLoadedSuccessfully, open, user, isDevelopment])
+  }, [open, user, isDevelopment, isLoading])
 
   const handleDevRoleSelect = (role: DevRole) => {
     setDevRole(role)
@@ -169,13 +162,7 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
                   </div>
 
                   <div className="space-y-3">
-                    <div className="flex justify-center min-h-[44px] items-center">
-                      {!scriptLoadedSuccessfully && !buttonTimedOut && (
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Loading sign-in...
-                        </div>
-                      )}
+                    <div className={`flex justify-center min-h-[44px] items-center ${isLoading ? "pointer-events-none opacity-50" : ""}`}>
                       <GoogleLogin
                         onSuccess={(response) => {
                           if (response.credential) {

--- a/job-finder-FE/src/components/auth/AuthModal.tsx
+++ b/job-finder-FE/src/components/auth/AuthModal.tsx
@@ -7,9 +7,9 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { useAuth, type DevRole } from "@/contexts/AuthContext"
-import { LogOut, Shield, Info, User, Eye, Crown } from "lucide-react"
-import { useState } from "react"
-import { useGoogleLogin } from "@react-oauth/google"
+import { LogOut, Shield, Info, User, Eye, Crown, Loader2 } from "lucide-react"
+import { useState, useEffect } from "react"
+import { GoogleLogin, useGoogleOAuth } from "@react-oauth/google"
 
 interface AuthModalProps {
   open: boolean
@@ -18,27 +18,28 @@ interface AuthModalProps {
 
 export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const { user, isOwner, signOut, loginWithGoogle, isDevelopment, setDevRole } = useAuth()
+  const { scriptLoadedSuccessfully } = useGoogleOAuth()
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [buttonTimedOut, setButtonTimedOut] = useState(false)
 
-  // Use the popup-based OAuth flow instead of the iframe-based GoogleLogin
-  // component. The iframe approach broke after Google's mandatory FedCM
-  // migration (August 2025) — the button silently fails to render.
-  // The popup flow opens accounts.google.com directly and returns an
-  // access token which the backend validates via Google's tokeninfo API.
-  const googleLogin = useGoogleLogin({
-    onSuccess: (response) => handleGoogleLogin(response.access_token),
-    onError: (errorResponse) => {
-      console.error("Google login error:", errorResponse)
-      setError("Failed to sign in with Google. Please try again.")
-    },
-    onNonOAuthError: (errorResponse) => {
-      // Popup closed, blocked, etc — don't show error for intentional cancellation
-      if (errorResponse.type === "popup_failed_to_open") {
-        setError("Popup was blocked. Please allow popups for this site.")
-      }
-    },
-  })
+  // The GoogleLogin component renders a button inside an iframe from Google.
+  // If the iframe fails to render (script blocked, FedCM issue), the space is
+  // blank with no error. Detect this and show an actionable message.
+  useEffect(() => {
+    if (!open || user || isDevelopment) {
+      setButtonTimedOut(false)
+      return
+    }
+    if (scriptLoadedSuccessfully) {
+      // Script loaded but button might still fail to render — give it time
+      const timer = setTimeout(() => setButtonTimedOut(true), 5000)
+      return () => clearTimeout(timer)
+    }
+    // Script itself didn't load
+    const timer = setTimeout(() => setButtonTimedOut(true), 5000)
+    return () => clearTimeout(timer)
+  }, [scriptLoadedSuccessfully, open, user, isDevelopment])
 
   const handleDevRoleSelect = (role: DevRole) => {
     setDevRole(role)
@@ -168,21 +169,47 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
                   </div>
 
                   <div className="space-y-3">
-                    <Button
-                      onClick={() => googleLogin()}
-                      variant="outline"
-                      className="w-full"
-                      size="lg"
-                      disabled={isLoading}
-                    >
-                      <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
-                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-                      </svg>
-                      {isLoading ? "Signing in..." : "Continue with Google"}
-                    </Button>
+                    <div className="flex justify-center min-h-[44px] items-center">
+                      {!scriptLoadedSuccessfully && !buttonTimedOut && (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Loading sign-in...
+                        </div>
+                      )}
+                      <GoogleLogin
+                        onSuccess={(response) => {
+                          if (response.credential) {
+                            handleGoogleLogin(response.credential)
+                          } else {
+                            setError("Missing credential from Google. Please try again.")
+                          }
+                        }}
+                        onError={() => setError("Failed to sign in. Please try again.")}
+                        useOneTap={false}
+                        size="large"
+                        theme="outline"
+                        text="continue_with"
+                        shape="rectangular"
+                      />
+                    </div>
+
+                    {buttonTimedOut && (
+                      <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                        <div className="flex items-start gap-2">
+                          <Info className="w-4 h-4 mt-0.5 text-amber-600 flex-shrink-0" />
+                          <div className="text-sm text-amber-700 dark:text-amber-400">
+                            <p className="font-medium mb-1">Google sign-in isn&apos;t loading</p>
+                            <p>This can happen if an ad blocker or browser privacy setting is blocking Google scripts. Try disabling your ad blocker for this site, or use a different browser.</p>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {isLoading && (
+                      <div className="text-sm text-muted-foreground text-center">
+                        Signing in...
+                      </div>
+                    )}
 
                     {error && (
                       <div className="text-sm text-destructive bg-destructive/10 rounded p-3">


### PR DESCRIPTION
useGoogleLogin (google.accounts.oauth2 API) opens a popup to Google's account chooser that loads as about:blank and never renders. The storagerelay:// redirect URI flow is failing at Google's end.

Revert to the original GoogleLogin component which uses google.accounts.id — a different API with a different popup flow that was previously working. Add a loading spinner while the GIS script loads, and keep the 5s timeout fallback message for when the button fails to render (ad blocker, FedCM issues).

The backend access token support from the previous commit is kept for future use but the frontend now sends JWT credentials again.

## Summary
Explain what changed and why. Mention the workspace(s) this touches (FE, API/server, Firebase functions, worker, shared types, infra, docs, etc.).

## Testing
Check everything you ran (or remove items that do not apply).
- [ ] `npm run lint:server`
- [ ] `npm run lint:functions`
- [ ] `npm run lint:frontend`
- [ ] `npm run build:server`
- [ ] `npm run build:frontend`
- [ ] Workspace-specific unit tests (`npm test --workspace ...`, `pytest`, etc.)
- [ ] Other (describe below)

## Checklist
- [ ] Added/updated docs, env samples, or SQL migrations if needed
- [ ] Added/updated types in `shared/` if API/worker contracts changed
- [ ] Verified relevant Husky hooks still pass locally
- [ ] Confirmed no secrets or personal data are committed

## Screenshots / Logs
Attach screenshots, terminal output, or logs if they help reviewers.

## Additional Notes
Anything else reviewers should know (rollout steps, follow-ups, blockers, related issues).
