### PR TITLE
Staging

### DIFF
--- a/job-finder-FE/src/components/layout/MainLayout.tsx
+++ b/job-finder-FE/src/components/layout/MainLayout.tsx
@@ -6,7 +6,7 @@ export function MainLayout() {
   return (
     <div className="min-h-screen bg-background/90 flex flex-col">
       <Navigation />
-      <main className="container mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8 flex-1">
+      <main className="mx-auto w-full max-w-7xl px-2 sm:px-4 lg:px-8 py-8 flex-1">
         <Outlet />
       </main>
       <Footer />

--- a/job-finder-FE/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/job-finder-FE/src/components/layout/__tests__/MainLayout.test.tsx
@@ -57,7 +57,7 @@ describe("MainLayout", () => {
     )
 
     const main = screen.getByTestId("outlet").parentElement
-    expect(main).toHaveClass("container", "mx-auto", "px-4", "py-8", "flex-1")
+    expect(main).toHaveClass("mx-auto", "w-full", "max-w-7xl", "py-8", "flex-1")
   })
 
   it("renders navigation at the top", () => {

--- a/job-finder-FE/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/job-finder-FE/src/components/layout/__tests__/MainLayout.test.tsx
@@ -57,7 +57,7 @@ describe("MainLayout", () => {
     )
 
     const main = screen.getByTestId("outlet").parentElement
-    expect(main).toHaveClass("mx-auto", "w-full", "max-w-7xl", "py-8", "flex-1")
+    expect(main).toHaveClass("mx-auto", "w-full", "max-w-7xl", "px-2", "sm:px-4", "lg:px-8", "py-8", "flex-1")
   })
 
   it("renders navigation at the top", () => {

--- a/job-finder-FE/src/pages/job-applications/JobApplicationsPage.tsx
+++ b/job-finder-FE/src/pages/job-applications/JobApplicationsPage.tsx
@@ -220,7 +220,7 @@ export function JobApplicationsPage() {
   }
 
   return (
-    <div className="space-y-6 p-4 sm:p-6">
+    <div className="space-y-6">
       {/* Header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Matches</h1>
@@ -274,7 +274,7 @@ export function JobApplicationsPage() {
 
       {/* Job Matches List */}
       <Card>
-        <CardHeader>
+        <CardHeader className="p-4 sm:p-6">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
               <CardTitle>Job Matches</CardTitle>
@@ -331,7 +331,7 @@ export function JobApplicationsPage() {
             </div>
           </div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="px-2 pb-4 sm:px-6 sm:pb-6">
           {loading ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -360,16 +360,16 @@ export function JobApplicationsPage() {
             </div>
           ) : (
             <div className="overflow-x-auto">
-              <Table>
+              <Table className="min-w-[640px]">
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="min-w-[180px]">Job Title</TableHead>
-                    <TableHead className="min-w-[140px]">Company</TableHead>
-                    <TableHead className="hidden md:table-cell min-w-[120px]">Location</TableHead>
-                    <TableHead className="hidden lg:table-cell min-w-[100px]">Posted</TableHead>
-                    <TableHead className="text-center min-w-[80px]">Score</TableHead>
-                    <TableHead className="hidden sm:table-cell min-w-[100px]">Status</TableHead>
-                    <TableHead className="text-center min-w-[80px]">Actions</TableHead>
+                    <TableHead className="min-w-[130px]">Job Title</TableHead>
+                    <TableHead className="min-w-[90px] max-w-[140px]">Company</TableHead>
+                    <TableHead className="min-w-[80px]">Location</TableHead>
+                    <TableHead className="min-w-[70px]">Posted</TableHead>
+                    <TableHead className="text-center min-w-[50px]">Score</TableHead>
+                    <TableHead className="min-w-[70px]">Status</TableHead>
+                    <TableHead className="text-center w-[44px]">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -379,12 +379,12 @@ export function JobApplicationsPage() {
                       className="cursor-pointer hover:bg-muted/50 active:bg-muted transition-colors"
                       onClick={() => handleRowClick(match)}
                     >
-                      <TableCell className="max-w-[300px]">
+                      <TableCell className="max-w-[200px]">
                         <div className="font-medium truncate" title={match.listing.title}>
                           {match.listing.title}
                         </div>
                       </TableCell>
-                      <TableCell className="max-w-[200px]">
+                      <TableCell className="max-w-[140px]">
                         <button
                           type="button"
                           className="text-blue-600 hover:underline text-left truncate block w-full"
@@ -399,24 +399,20 @@ export function JobApplicationsPage() {
                         >
                           {match.listing.companyName}
                         </button>
-                        {/* Show location on mobile as secondary text */}
-                        <div className="md:hidden text-xs text-muted-foreground mt-0.5 truncate">
-                          {match.listing.location || ""}
-                        </div>
                       </TableCell>
-                      <TableCell className="hidden md:table-cell text-muted-foreground max-w-[160px]">
+                      <TableCell className="text-muted-foreground max-w-[120px]">
                         <span className="truncate block" title={match.listing.location || undefined}>
                           {match.listing.location || "—"}
                         </span>
                       </TableCell>
-                      <TableCell className="hidden lg:table-cell text-muted-foreground whitespace-nowrap">
+                      <TableCell className="text-muted-foreground whitespace-nowrap">
                         {formatDate(match.listing.postedDate)}
                       </TableCell>
                       <TableCell className="text-center whitespace-nowrap">
                         <span className={getScoreColor(match.matchScore)}>{match.matchScore}%</span>
                       </TableCell>
-                      <TableCell className="hidden sm:table-cell">
-                        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ${statusBadgeClass(match.status ?? "active")}`}>
+                      <TableCell>
+                        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap ${statusBadgeClass(match.status ?? "active")}`}>
                           {match.status ?? "active"}
                         </span>
                       </TableCell>

--- a/job-finder-FE/src/pages/job-listings/JobListingsPage.tsx
+++ b/job-finder-FE/src/pages/job-listings/JobListingsPage.tsx
@@ -279,7 +279,7 @@ export function JobListingsPage() {
 
       {/* Listings Table */}
       <Card>
-        <CardHeader>
+        <CardHeader className="p-4 sm:p-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <CardTitle>Job Listings</CardTitle>
@@ -335,7 +335,7 @@ export function JobListingsPage() {
             </div>
           </div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="px-2 pb-4 sm:px-6 sm:pb-6">
           <div className="overflow-x-auto">
             <JobListingsTable
               listings={filteredListings}

--- a/job-finder-FE/src/pages/job-listings/components/JobListingsTable.tsx
+++ b/job-finder-FE/src/pages/job-listings/components/JobListingsTable.tsx
@@ -59,15 +59,15 @@ export function JobListingsTable({
   }
 
   return (
-    <Table>
+    <Table className="min-w-[580px]">
       <TableHeader>
         <TableRow>
-          <TableHead className="min-w-[180px]">Title</TableHead>
-          <TableHead className="hidden md:table-cell min-w-[140px]">Company</TableHead>
-          <TableHead className="hidden lg:table-cell min-w-[120px]">Location</TableHead>
-          <TableHead className="hidden sm:table-cell min-w-[80px]">Score</TableHead>
-          <TableHead className="min-w-[100px]">Status</TableHead>
-          <TableHead className="hidden md:table-cell min-w-[120px]">Updated</TableHead>
+          <TableHead className="min-w-[130px]">Title</TableHead>
+          <TableHead className="min-w-[90px] max-w-[140px]">Company</TableHead>
+          <TableHead className="min-w-[80px]">Location</TableHead>
+          <TableHead className="min-w-[50px]">Score</TableHead>
+          <TableHead className="min-w-[70px]">Status</TableHead>
+          <TableHead className="min-w-[70px]">Updated</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -77,26 +77,10 @@ export function JobListingsTable({
             className="cursor-pointer hover:bg-muted/50 active:bg-muted transition-colors"
             onClick={() => onRowClick(listing)}
           >
-            <TableCell className="max-w-[300px]">
+            <TableCell className="max-w-[200px]">
               <div className="font-medium truncate">{listing.title}</div>
-              {/* Show company and location on mobile as secondary text */}
-              <div className="md:hidden text-xs text-muted-foreground mt-0.5 flex min-w-0">
-                <span className="truncate">
-                  <button
-                    type="button"
-                    className="text-blue-600 hover:underline"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onCompanyClick(listing.companyId || undefined)
-                    }}
-                  >
-                    {listing.companyName}
-                  </button>
-                </span>
-                {listing.location && <span className="flex-shrink-0">{` • ${listing.location}`}</span>}
-              </div>
             </TableCell>
-            <TableCell className="hidden md:table-cell max-w-[200px]">
+            <TableCell className="max-w-[140px]">
               <button
                 type="button"
                 className="text-blue-600 hover:underline text-left truncate block w-full"
@@ -108,17 +92,17 @@ export function JobListingsTable({
                 {listing.companyName}
               </button>
             </TableCell>
-            <TableCell className="hidden lg:table-cell text-muted-foreground max-w-[160px]">
+            <TableCell className="text-muted-foreground max-w-[120px]">
               <span className="truncate block" title={listing.location || undefined}>{listing.location || "—"}</span>
             </TableCell>
-            <TableCell className="hidden sm:table-cell text-muted-foreground">
+            <TableCell className="text-muted-foreground">
               {(() => {
                 const score = extractMatchScore(listing)
                 return score !== null ? `${score}` : "—"
               })()}
             </TableCell>
             <TableCell>{getStatusBadge(listing.status)}</TableCell>
-            <TableCell className="hidden md:table-cell text-muted-foreground text-sm whitespace-nowrap">
+            <TableCell className="text-muted-foreground text-sm whitespace-nowrap">
               {formatDateTime(listing.updatedAt)}
             </TableCell>
           </TableRow>


### PR DESCRIPTION
## Summary
Improves table responsiveness across the Matches and Job Listings pages (FE workspace). Tables previously hid columns at breakpoints and compressed content on narrow viewports with no horizontal scroll — now all columns are always visible and scroll horizontally when space is tight.

**Key changes:**
- **MainLayout**: Replaced `container max-w-6xl` with `w-full max-w-7xl` to remove Tailwind's breakpoint-based max-width caps that were constraining layout width on narrow desktops
- **Matches & Job Listings tables**: Removed all `hidden sm/md/lg:table-cell` responsive hiding — all columns always render. Added `min-w-[640px]`/`min-w-[580px]` on each table so columns stay readable and `overflow-x-auto` triggers a horizontal scrollbar instead of compressing
- **Padding reduction**: Removed duplicate page-level padding on JobApplicationsPage, reduced CardHeader/CardContent padding on small screens (`px-2 pb-4 sm:px-6 sm:pb-6`), and tightened MainLayout mobile padding (`px-2 sm:px-4 lg:px-8`)
- **Column widths**: Tightened min-width/max-width on Company and other columns to eliminate dead space

## Testing
- [x] `npm run lint:frontend`
- [x] `npm run build:frontend`
- [x] Workspace-specific unit tests (762 passed, 0 failed)
- [x] Integration tests (85 passed)
- [x] Verified Husky pre-push hooks pass locally

## Checklist
- [x] Confirmed no secrets or personal data are committed

## Additional Notes
The `container` utility in Tailwind enforces breakpoint-based max-widths (768px at md, 1024px at lg) which was the primary cause of table cramping on vertical desktop monitors. Replacing it with a flat `max-w-7xl` lets the content use available viewport width up to 1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)