### PR TITLE
Staging

### DIFF
--- a/infra/sqlite/migrations/070_job_match_static_score.sql
+++ b/infra/sqlite/migrations/070_job_match_static_score.sql
@@ -1,0 +1,9 @@
+-- Add `static_score` to job_matches: the deterministic match score WITHOUT the
+-- freshness component. The API computes freshness adjustments live from
+-- job_listings.posted_date / created_at so an aging listing decays toward the
+-- staleScore without requiring a periodic re-score job.
+--
+-- NULL for legacy rows scored before this migration; the API falls back to
+-- the stored match_score when static_score is missing.
+
+ALTER TABLE job_matches ADD COLUMN static_score INTEGER;

--- a/job-finder-BE/server/src/modules/job-matches/__tests__/freshness-scorer.test.ts
+++ b/job-finder-BE/server/src/modules/job-matches/__tests__/freshness-scorer.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { FreshnessConfig } from '@shared/types'
+import {
+  computeLiveFreshnessAdjustment,
+  clampScore,
+  clearFreshnessConfigCache,
+  loadFreshnessConfig
+} from '../freshness-scorer'
+import { ConfigRepository } from '../../config/config.repository'
+import { getDb } from '../../../db/sqlite'
+
+const baseConfig: FreshnessConfig = {
+  freshDays: 3,
+  freshScore: 10,
+  staleDays: 7,
+  staleScore: -10,
+  veryStaleDays: 14,
+  veryStaleScore: -20,
+  repostScore: -5
+}
+
+const NOW = new Date('2026-05-14T12:00:00Z')
+const daysAgo = (days: number) => new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000)
+
+describe('computeLiveFreshnessAdjustment', () => {
+  it('returns freshScore inside the freshness window', () => {
+    expect(computeLiveFreshnessAdjustment(daysAgo(0), baseConfig, NOW)).toBe(10)
+    expect(computeLiveFreshnessAdjustment(daysAgo(3), baseConfig, NOW)).toBe(10)
+  })
+
+  it('returns 0 between freshDays and staleDays', () => {
+    expect(computeLiveFreshnessAdjustment(daysAgo(4), baseConfig, NOW)).toBe(0)
+    expect(computeLiveFreshnessAdjustment(daysAgo(6.5), baseConfig, NOW)).toBe(0)
+  })
+
+  it('returns staleScore at staleDays threshold', () => {
+    expect(computeLiveFreshnessAdjustment(daysAgo(7), baseConfig, NOW)).toBe(-10)
+    expect(computeLiveFreshnessAdjustment(daysAgo(13), baseConfig, NOW)).toBe(-10)
+  })
+
+  it('returns veryStaleScore at veryStaleDays threshold', () => {
+    expect(computeLiveFreshnessAdjustment(daysAgo(14), baseConfig, NOW)).toBe(-20)
+    expect(computeLiveFreshnessAdjustment(daysAgo(60), baseConfig, NOW)).toBe(-20)
+  })
+
+  it('returns 0 for null / undefined / unparseable', () => {
+    expect(computeLiveFreshnessAdjustment(null, baseConfig, NOW)).toBe(0)
+    expect(computeLiveFreshnessAdjustment(undefined, baseConfig, NOW)).toBe(0)
+    expect(computeLiveFreshnessAdjustment('not-a-date', baseConfig, NOW)).toBe(0)
+  })
+
+  it('accepts ISO strings', () => {
+    expect(computeLiveFreshnessAdjustment(daysAgo(2).toISOString(), baseConfig, NOW)).toBe(10)
+  })
+
+  it('accepts Firestore-style {seconds} timestamps', () => {
+    const seconds = Math.floor(daysAgo(20).getTime() / 1000)
+    expect(computeLiveFreshnessAdjustment({ seconds } as unknown as Date, baseConfig, NOW)).toBe(-20)
+  })
+})
+
+describe('clampScore', () => {
+  it('clamps to [0,100] and rounds', () => {
+    expect(clampScore(-5)).toBe(0)
+    expect(clampScore(150)).toBe(100)
+    expect(clampScore(72.4)).toBe(72)
+    expect(clampScore(NaN)).toBe(0)
+  })
+})
+
+describe('loadFreshnessConfig', () => {
+  beforeEach(() => {
+    clearFreshnessConfigCache()
+    const db = getDb()
+    db.prepare("DELETE FROM job_finder_config WHERE id = 'match-policy'").run()
+  })
+
+  it('returns null when match-policy is not seeded', () => {
+    expect(loadFreshnessConfig(new ConfigRepository())).toBeNull()
+  })
+
+  it('returns the freshness section when match-policy exists', () => {
+    new ConfigRepository().upsert('match-policy', {
+      minScore: 65,
+      seniority: { preferred: [], acceptable: [], rejected: [], preferredScore: 0, acceptableScore: 0, rejectedScore: 0 },
+      location: { allowRemote: true, allowHybrid: true, allowOnsite: false, userTimezone: -8, maxTimezoneDiffHours: 4, perHourScore: -1, hybridSameCityScore: 0, userCity: '', remoteScore: 0, relocationScore: 0, unknownTimezoneScore: 0, relocationAllowed: false },
+      skillMatch: { baseMatchScore: 2, yearsMultiplier: 0.5, maxYearsBonus: 5, missingScore: -2, missingIgnore: [], analogScore: 0, maxBonus: 25, maxPenalty: -15 },
+      salary: { minimum: 100000, target: 150000, belowTargetScore: -2, belowTargetMaxPenalty: -20, missingSalaryScore: 0, meetsTargetScore: 5, equityScore: 5, contractScore: -15 },
+      freshness: baseConfig,
+      roleFit: { preferred: [], acceptable: [], penalized: [], rejected: [], preferredScore: 0, penalizedScore: 0 },
+      company: { preferredCityScore: 0, preferredCity: '', remoteFirstScore: 0, aiMlFocusScore: 0, largeCompanyScore: 0, smallCompanyScore: 0, largeCompanyThreshold: 10000, smallCompanyThreshold: 100, startupScore: 0 },
+      experience: {}
+    } as unknown as Parameters<ConfigRepository['upsert']>[1], { updatedBy: 'test' })
+
+    const loaded = loadFreshnessConfig(new ConfigRepository())
+    expect(loaded).toEqual(baseConfig)
+  })
+})

--- a/job-finder-BE/server/src/modules/job-matches/freshness-scorer.ts
+++ b/job-finder-BE/server/src/modules/job-matches/freshness-scorer.ts
@@ -1,0 +1,85 @@
+/**
+ * Live freshness adjustment for match scores.
+ *
+ * The deterministic ScoringEngine in the worker bakes a freshness component
+ * into the match score at analyze-time. That's a snapshot — a listing posted
+ * a day ago and scored "fresh" (+10) keeps that bonus forever even after it
+ * goes stale. The worker now stores a `static_score` (score minus freshness)
+ * so this module can recompute the freshness adjustment using the listing's
+ * actual age relative to NOW.
+ *
+ * Mirrors `_score_freshness` in `scoring/engine.py`:
+ *   - days_old <= freshDays     -> +freshScore
+ *   - days_old >= veryStaleDays -> +veryStaleScore (typically negative)
+ *   - days_old >= staleDays     -> +staleScore     (typically negative)
+ *   - in between                -> 0
+ * (Repost penalty is intentionally not modeled here; it's a one-time signal
+ *  from extraction, not a function of elapsed time.)
+ */
+
+import type { FreshnessConfig, MatchPolicy } from '@shared/types'
+import { ConfigRepository } from '../config/config.repository'
+
+const CACHE_TTL_MS = 60_000
+
+let cached: { config: FreshnessConfig; loadedAt: number } | null = null
+
+/**
+ * Load the freshness portion of match-policy with a short in-process cache so
+ * read-heavy match list endpoints don't hammer the config repository.
+ */
+export function loadFreshnessConfig(repo: ConfigRepository = new ConfigRepository()): FreshnessConfig | null {
+  const now = Date.now()
+  if (cached && now - cached.loadedAt < CACHE_TTL_MS) return cached.config
+
+  const entry = repo.get<MatchPolicy>('match-policy')
+  const freshness = entry?.payload?.freshness
+  if (!freshness) {
+    cached = null
+    return null
+  }
+  cached = { config: freshness, loadedAt: now }
+  return freshness
+}
+
+/** Drop the in-process cache. Useful for tests and for clearing after config edits. */
+export function clearFreshnessConfigCache(): void {
+  cached = null
+}
+
+/** Pure function — given a snapshot of the freshness policy and timestamps, return the adjustment. */
+export function computeLiveFreshnessAdjustment(
+  reference: Date | string | { seconds?: number; _seconds?: number } | null | undefined,
+  config: FreshnessConfig,
+  now: Date = new Date()
+): number {
+  if (!reference) return 0
+  let ts: Date
+  if (reference instanceof Date) {
+    ts = reference
+  } else if (typeof reference === 'string') {
+    ts = new Date(reference)
+  } else if (typeof reference === 'object') {
+    const seconds = (reference as { seconds?: number; _seconds?: number }).seconds ??
+      (reference as { seconds?: number; _seconds?: number })._seconds
+    if (typeof seconds !== 'number') return 0
+    ts = new Date(seconds * 1000)
+  } else {
+    return 0
+  }
+  if (Number.isNaN(ts.getTime())) return 0
+
+  const days = Math.max(0, (now.getTime() - ts.getTime()) / (24 * 60 * 60 * 1000))
+  if (days <= config.freshDays) return config.freshScore
+  if (days >= config.veryStaleDays) return config.veryStaleScore
+  if (days >= config.staleDays) return config.staleScore
+  return 0
+}
+
+/** Clamp the final live-adjusted score to the same 0..100 range the engine uses. */
+export function clampScore(score: number): number {
+  if (Number.isNaN(score)) return 0
+  if (score < 0) return 0
+  if (score > 100) return 100
+  return Math.round(score)
+}

--- a/job-finder-BE/server/src/modules/job-matches/job-match.repository.ts
+++ b/job-finder-BE/server/src/modules/job-matches/job-match.repository.ts
@@ -4,11 +4,13 @@ import type { JobMatch, JobMatchWithListing, JobListingRecord, JobListingStatus,
 import { getDb } from '../../db/sqlite'
 import { JobListingRepository } from '../job-listings/job-listing.repository'
 import { CompanyRepository } from '../companies/company.repository'
+import { loadFreshnessConfig, computeLiveFreshnessAdjustment, clampScore } from './freshness-scorer'
 
 type JobMatchRow = {
   id: string
   job_listing_id: string
   match_score: number
+  static_score: number | null
   matched_skills: string | null
   missing_skills: string | null
   match_reasons: string | null
@@ -49,10 +51,23 @@ const parseJsonArray = (value: string | null): string[] => {
   }
 }
 
+function applyLiveFreshness(
+  match: JobMatch,
+  listing: JobListingRecord,
+  freshness: ReturnType<typeof loadFreshnessConfig>,
+  now: Date
+): JobMatch {
+  if (!freshness || match.staticScore == null) return match
+  const reference = listing.postedDate ?? listing.createdAt
+  const adjustment = computeLiveFreshnessAdjustment(reference, freshness, now)
+  return { ...match, matchScore: clampScore(match.staticScore + adjustment) }
+}
+
 const buildJobMatch = (row: JobMatchRow): JobMatch => ({
   id: row.id,
   jobListingId: row.job_listing_id,
   matchScore: row.match_score,
+  staticScore: row.static_score,
   matchedSkills: parseJsonArray(row.matched_skills),
   missingSkills: parseJsonArray(row.missing_skills),
   matchReasons: parseJsonArray(row.match_reasons),
@@ -356,6 +371,11 @@ export class JobMatchRepository {
 
     const rows = this.db.prepare(sql).all(...params, limit, offset) as JoinedRow[]
 
+    // Load freshness policy once for the whole batch so we re-apply the same
+    // age curve to every match without hitting the config repo per row.
+    const freshnessConfig = loadFreshnessConfig()
+    const now = new Date()
+
     return rows.map((row) => {
       const match = buildJobMatch(row)
       if (match.isGhost || !row.l_id || row.l_id === '__ghost_listing__') {
@@ -380,13 +400,22 @@ export class JobMatchRepository {
         }
         return { ...match, listing: ghostListing, company: null }
       }
+      const listing = buildListingFromRow(row)
+      const live = applyLiveFreshness(match, listing, freshnessConfig, now)
       return {
-        ...match,
-        listing: buildListingFromRow(row),
+        ...live,
+        listing,
         company: buildCompanyFromRow(row)
       }
     })
   }
+
+  /**
+   * Re-derive `matchScore` from `staticScore` + the listing's current age so
+   * a job posted a week ago decays toward the staleScore even if it was
+   * scored when it was fresh. Falls back to the stored match_score when
+   * static_score is NULL (legacy rows that haven't been re-scored yet).
+   */
 
   getById(id: string): JobMatch | null {
     const row = this.db.prepare('SELECT * FROM job_matches WHERE id = ?').get(id) as JobMatchRow | undefined
@@ -425,8 +454,8 @@ export class JobMatchRepository {
     if (!listing) return null
 
     const company = listing.companyId ? this.companyRepo.getById(listing.companyId) : null
-
-    return { ...match, listing, company }
+    const live = applyLiveFreshness(match, listing, loadFreshnessConfig(), new Date())
+    return { ...live, listing, company }
   }
 
   getByJobListingId(jobListingId: string): JobMatch | null {
@@ -444,15 +473,16 @@ export class JobMatchRepository {
 
     const stmt = this.db.prepare(`
       INSERT INTO job_matches (
-        id, job_listing_id, match_score, matched_skills, missing_skills,
+        id, job_listing_id, match_score, static_score, matched_skills, missing_skills,
         match_reasons, key_strengths, potential_concerns, experience_match,
         customization_recommendations, resume_intake_json,
         analyzed_at, submitted_by, queue_item_id, created_at, updated_at,
         status, ignored_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         job_listing_id = excluded.job_listing_id,
         match_score = excluded.match_score,
+        static_score = excluded.static_score,
         matched_skills = excluded.matched_skills,
         missing_skills = excluded.missing_skills,
         match_reasons = excluded.match_reasons,
@@ -473,6 +503,7 @@ export class JobMatchRepository {
       id,
       match.jobListingId,
       match.matchScore,
+      match.staticScore ?? null,
       JSON.stringify(match.matchedSkills ?? []),
       JSON.stringify(match.missingSkills ?? []),
       JSON.stringify(match.matchReasons ?? []),

--- a/job-finder-worker/src/job_finder/ai/matcher.py
+++ b/job-finder-worker/src/job_finder/ai/matcher.py
@@ -49,6 +49,14 @@ class JobMatchResult(BaseModel):
 
     # Match Analysis
     match_score: int = Field(..., ge=0, le=100, description="Overall match score (0-100)")
+    static_score: Optional[int] = Field(
+        default=None,
+        description=(
+            "Deterministic score without the freshness component. The API adds "
+            "freshness live from the listing's posted_date so the score decays "
+            "as the listing ages."
+        ),
+    )
     matched_skills: List[str] = Field(default_factory=list)
     missing_skills: List[str] = Field(default_factory=list)
     experience_match: str = ""
@@ -145,6 +153,11 @@ class AIJobMatcher:
                     "All jobs must be scored by ScoringEngine before AI analysis."
                 )
             match_score = int(deterministic_score)
+            # The freshness contribution is removed at storage time so the API can
+            # recompute freshness live from the listing's posted_date.
+            static_score = job.get("deterministic_static_score")
+            if static_score is not None:
+                static_score = int(static_score)
 
             # Build score breakdown
             score_breakdown = ScoreBreakdown(
@@ -163,7 +176,9 @@ class AIJobMatcher:
                 return None
 
             # Build and return result
-            result = self._build_match_result(job, match_analysis, match_score, score_breakdown)
+            result = self._build_match_result(
+                job, match_analysis, match_score, score_breakdown, static_score=static_score
+            )
 
             logger.info(f"Successfully analyzed {job.get('title')} - Score: {match_score}")
             return result
@@ -178,6 +193,7 @@ class AIJobMatcher:
         match_analysis: Dict[str, Any],
         match_score: int,
         score_breakdown: Optional[ScoreBreakdown] = None,
+        static_score: Optional[int] = None,
     ) -> JobMatchResult:
         """
         Build JobMatchResult from job data and analysis.
@@ -203,6 +219,7 @@ class AIJobMatcher:
             salary_range=job.get("salary") or job.get("salary_range"),
             company_info=job.get("company_info"),
             match_score=match_score,
+            static_score=static_score,
             matched_skills=matched_skills,
             missing_skills=missing_skills,
             experience_match=match_analysis.get("experience_match", ""),

--- a/job-finder-worker/src/job_finder/job_queue/processors/job_processor.py
+++ b/job-finder-worker/src/job_finder/job_queue/processors/job_processor.py
@@ -1095,7 +1095,9 @@ class JobProcessor(BaseProcessor):
             **job_data,
             "extraction": ctx.extraction.to_dict() if ctx.extraction else {},
             "deterministic_score": ctx.score_result.final_score if ctx.score_result else 0,
-            "deterministic_static_score": ctx.score_result.static_score if ctx.score_result else None,
+            "deterministic_static_score": (
+                ctx.score_result.static_score if ctx.score_result else None
+            ),
         }
 
         try:

--- a/job-finder-worker/src/job_finder/job_queue/processors/job_processor.py
+++ b/job-finder-worker/src/job_finder/job_queue/processors/job_processor.py
@@ -1095,6 +1095,7 @@ class JobProcessor(BaseProcessor):
             **job_data,
             "extraction": ctx.extraction.to_dict() if ctx.extraction else {},
             "deterministic_score": ctx.score_result.final_score if ctx.score_result else 0,
+            "deterministic_static_score": ctx.score_result.static_score if ctx.score_result else None,
         }
 
         try:

--- a/job-finder-worker/src/job_finder/rescore_matches.py
+++ b/job-finder-worker/src/job_finder/rescore_matches.py
@@ -38,7 +38,6 @@ import json
 import logging
 import sys
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -133,9 +132,7 @@ def rescore_one(
         return None  # No snapshot to re-score against; skip silently
 
     extraction = JobExtractionResult.from_dict(extraction_dict)
-    breakdown = engine.score(
-        extraction, record.get("title") or "", record.get("description") or ""
-    )
+    breakdown = engine.score(extraction, record.get("title") or "", record.get("description") or "")
 
     new_match_score = breakdown.final_score
     new_static_score = breakdown.static_score
@@ -278,10 +275,12 @@ def main() -> int:
         )
 
     import os
+
     db_path = os.environ.get("SQLITE_DB_PATH")
     if not db_path:
         try:
             from job_finder.storage.sqlite_client import resolve_db_path
+
             db_path = resolve_db_path(None)
         except Exception as exc:
             logger.error("Could not resolve a SQLite path: %s", exc)

--- a/job-finder-worker/src/job_finder/rescore_matches.py
+++ b/job-finder-worker/src/job_finder/rescore_matches.py
@@ -1,0 +1,350 @@
+"""Re-score job_matches using the current match-policy + prefilter config.
+
+This is a one-shot maintenance command. It walks every job_match in the
+requested status set and re-runs the deterministic ScoringEngine against the
+listing's stored extraction snapshot (filter_result.extraction). That avoids
+re-doing any AI work — we only re-apply the math against the new config.
+
+For each match:
+  - `match_score` is updated to the new final_score
+  - `static_score` is set so the API's live-freshness path takes over
+  - `job_listings.match_score` is refreshed in lockstep
+  - If `status='active'` AND new score < match-policy.minScore, the row is
+    flipped to `status='ignored'` with `status_updated_by='reconciliation-script'`
+    and an `application_status_history` audit row.
+
+Statuses NOT touched: `applied`, `acknowledged`, `interviewing`, `denied`.
+Their score is updated for visibility but their status is preserved — those
+represent real user/recruiter signal that re-scoring must not blow away.
+
+Usage:
+    # Dry run (default — prints what would change)
+    ENVIRONMENT=production python -m job_finder.rescore_matches --dry-run
+
+    # Apply changes
+    ENVIRONMENT=production python -m job_finder.rescore_matches
+
+    # Limit which statuses get re-evaluated (default: active,ignored)
+    python -m job_finder.rescore_matches --statuses active
+
+    # Process only N matches (useful for spot-checking)
+    python -m job_finder.rescore_matches --limit 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+# Add src to path when run as a script
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from job_finder.ai.extraction import JobExtractionResult
+from job_finder.filters.title_filter import TitleFilter
+from job_finder.job_queue.config_loader import ConfigLoader
+from job_finder.profile.reducer import load_scoring_profile
+from job_finder.scoring.engine import ScoringEngine
+from job_finder.scoring.taxonomy import SkillTaxonomyRepository
+from job_finder.storage.sqlite_client import sqlite_connection, utcnow_iso
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATUSES = ("active", "ignored")
+TERMINAL_USER_STATUSES = frozenset({"applied", "acknowledged", "interviewing", "denied"})
+
+
+def build_engine(config_loader: ConfigLoader, db_path: Optional[str]) -> ScoringEngine:
+    match_policy = config_loader.get_match_policy()
+    personal_info = config_loader.get_personal_info() or {}
+    location_config = match_policy.setdefault("location", {})
+    if personal_info.get("timezone") is not None:
+        location_config["userTimezone"] = personal_info["timezone"]
+    if personal_info.get("city"):
+        location_config["userCity"] = personal_info["city"]
+    if "relocationAllowed" in personal_info:
+        location_config["relocationAllowed"] = personal_info["relocationAllowed"]
+
+    relevant_exp_start = match_policy.get("experience", {}).get("relevantExperienceStart")
+    profile = load_scoring_profile(db_path, relevant_experience_start=relevant_exp_start)
+    taxonomy_repo = SkillTaxonomyRepository(db_path)
+
+    return ScoringEngine(
+        match_policy,
+        skill_years=profile.skill_years,
+        user_experience_years=profile.total_experience_years,
+        taxonomy_repo=taxonomy_repo,
+    )
+
+
+def parse_filter_result(raw: Optional[str]) -> Dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except (TypeError, ValueError):
+        return {}
+
+
+def fetch_candidates(
+    db_path: str, statuses: Set[str], limit: Optional[int]
+) -> List[Dict[str, Any]]:
+    placeholders = ",".join("?" for _ in statuses)
+    sql = f"""
+        SELECT m.id            AS match_id,
+               m.status        AS status,
+               m.match_score   AS old_match_score,
+               m.static_score  AS old_static_score,
+               l.id            AS listing_id,
+               l.title         AS title,
+               l.description   AS description,
+               l.filter_result AS filter_result
+          FROM job_matches m
+          JOIN job_listings l ON l.id = m.job_listing_id
+         WHERE m.status IN ({placeholders})
+           AND m.is_ghost = 0
+         ORDER BY m.analyzed_at DESC
+    """
+    params: List[Any] = list(statuses)
+    if limit:
+        sql += " LIMIT ?"
+        params.append(limit)
+
+    with sqlite_connection(db_path) as conn:
+        return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+
+def rescore_one(
+    engine: ScoringEngine,
+    record: Dict[str, Any],
+    min_score: int,
+    title_filter: Optional[TitleFilter] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return a diff dict if the row needs an UPDATE, else None."""
+    filter_result = parse_filter_result(record.get("filter_result"))
+    extraction_dict = (filter_result or {}).get("extraction")
+    if not extraction_dict:
+        return None  # No snapshot to re-score against; skip silently
+
+    extraction = JobExtractionResult.from_dict(extraction_dict)
+    breakdown = engine.score(
+        extraction, record.get("title") or "", record.get("description") or ""
+    )
+
+    new_match_score = breakdown.final_score
+    new_static_score = breakdown.static_score
+    old_match_score = int(record.get("old_match_score") or 0)
+    old_static_score = record.get("old_static_score")
+
+    status = record["status"]
+    next_status = status
+    note: Optional[str] = None
+
+    # If the current title prefilter would now reject this listing, take that
+    # as a stronger signal than the numeric score and ignore the row.
+    title = record.get("title") or ""
+    if title_filter is not None and status == "active":
+        title_result = title_filter.filter(title)
+        if not title_result.passed:
+            next_status = "ignored"
+            note = (
+                f"auto-reconciled: current title prefilter rejects this listing "
+                f"({title_result.reason})"
+            )
+
+    # Only auto-flip ACTIVE rows; ignored stays ignored, terminal stays terminal.
+    if next_status == status and status == "active" and new_match_score < min_score:
+        next_status = "ignored"
+        note = (
+            f"auto-reconciled: re-score dropped {old_match_score} -> {new_match_score} "
+            f"(below minScore {min_score})"
+        )
+
+    if (
+        new_match_score == old_match_score
+        and new_static_score == old_static_score
+        and next_status == status
+    ):
+        return None  # No-op
+
+    return {
+        "match_id": record["match_id"],
+        "listing_id": record["listing_id"],
+        "old_match_score": old_match_score,
+        "old_static_score": old_static_score,
+        "new_match_score": new_match_score,
+        "new_static_score": new_static_score,
+        "status": status,
+        "next_status": next_status,
+        "note": note,
+        "breakdown": breakdown.to_dict(),
+    }
+
+
+def apply_changes(db_path: str, changes: List[Dict[str, Any]]) -> None:
+    if not changes:
+        return
+    now = utcnow_iso()
+    with sqlite_connection(db_path) as conn:
+        for change in changes:
+            conn.execute(
+                """
+                UPDATE job_matches
+                   SET match_score = ?,
+                       static_score = ?,
+                       updated_at = ?
+                 WHERE id = ?
+                """,
+                (
+                    change["new_match_score"],
+                    change["new_static_score"],
+                    now,
+                    change["match_id"],
+                ),
+            )
+
+            if change["next_status"] != change["status"]:
+                conn.execute(
+                    """
+                    UPDATE job_matches
+                       SET status = ?,
+                           status_note = ?,
+                           status_updated_by = 'reconciliation-script',
+                           ignored_at = CASE WHEN ? = 'ignored' THEN ? ELSE ignored_at END
+                     WHERE id = ?
+                    """,
+                    (
+                        change["next_status"],
+                        change["note"],
+                        change["next_status"],
+                        now,
+                        change["match_id"],
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO application_status_history
+                       (id, job_match_id, from_status, to_status, changed_by,
+                        application_email_id, note, created_at)
+                    VALUES (?, ?, ?, ?, 'reconciliation-script', NULL, ?, ?)
+                    """,
+                    (
+                        str(uuid.uuid4()),
+                        change["match_id"],
+                        change["status"],
+                        change["next_status"],
+                        change["note"],
+                        now,
+                    ),
+                )
+
+            conn.execute(
+                "UPDATE job_listings SET match_score = ?, updated_at = ? WHERE id = ?",
+                (change["new_match_score"], now, change["listing_id"]),
+            )
+        conn.commit()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Re-score job_matches under current config")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without applying")
+    parser.add_argument(
+        "--statuses",
+        type=str,
+        default=",".join(DEFAULT_STATUSES),
+        help=f"Comma-separated job_matches.status values to consider (default: {','.join(DEFAULT_STATUSES)})",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Max matches to process")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    statuses = {s.strip().lower() for s in args.statuses.split(",") if s.strip()}
+    overlap = statuses & TERMINAL_USER_STATUSES
+    if overlap:
+        logger.warning(
+            "Including user-terminal statuses %s — these will be re-scored but never auto-flipped.",
+            sorted(overlap),
+        )
+
+    import os
+    db_path = os.environ.get("SQLITE_DB_PATH")
+    if not db_path:
+        try:
+            from job_finder.storage.sqlite_client import resolve_db_path
+            db_path = resolve_db_path(None)
+        except Exception as exc:
+            logger.error("Could not resolve a SQLite path: %s", exc)
+            return 2
+    config_loader = ConfigLoader(db_path=db_path)
+
+    match_policy = config_loader.get_match_policy()
+    min_score = int(match_policy.get("minScore", 0))
+    engine = build_engine(config_loader, db_path)
+
+    prefilter_policy = config_loader.get_prefilter_policy() or {}
+    title_filter = (
+        TitleFilter(prefilter_policy.get("title") or {})
+        if (prefilter_policy.get("title") or {}).get("requiredKeywords")
+        else None
+    )
+
+    candidates = fetch_candidates(db_path, statuses, args.limit)
+    logger.info("Loaded %d candidate matches (statuses=%s)", len(candidates), sorted(statuses))
+
+    changes: List[Dict[str, Any]] = []
+    flipped = 0
+    skipped_no_extraction = 0
+
+    for rec in candidates:
+        diff = rescore_one(engine, rec, min_score, title_filter=title_filter)
+        if diff is None:
+            if not parse_filter_result(rec.get("filter_result")).get("extraction"):
+                skipped_no_extraction += 1
+            continue
+        changes.append(diff)
+        if diff["next_status"] != diff["status"]:
+            flipped += 1
+
+    logger.info(
+        "Planned changes: %d (status flips: %d, skipped no-extraction: %d)",
+        len(changes),
+        flipped,
+        skipped_no_extraction,
+    )
+
+    if args.verbose:
+        for c in changes[:20]:
+            logger.info(
+                "  %s: %s->%s, score %d->%d (static %s->%d)%s",
+                c["match_id"][:8],
+                c["status"],
+                c["next_status"],
+                c["old_match_score"],
+                c["new_match_score"],
+                c["old_static_score"],
+                c["new_static_score"],
+                f"  [{c['note']}]" if c["note"] else "",
+            )
+
+    if args.dry_run:
+        logger.info("[DRY RUN] no changes applied")
+        return 0
+
+    apply_changes(db_path, changes)
+    logger.info("Applied %d changes", len(changes))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/job-finder-worker/src/job_finder/rescore_matches.py
+++ b/job-finder-worker/src/job_finder/rescore_matches.py
@@ -276,15 +276,19 @@ def main() -> int:
 
     import os
 
-    db_path = os.environ.get("SQLITE_DB_PATH")
+    db_path: Optional[str] = os.environ.get("SQLITE_DB_PATH")
     if not db_path:
         try:
             from job_finder.storage.sqlite_client import resolve_db_path
 
-            db_path = resolve_db_path(None)
+            resolved = resolve_db_path(None)
+            db_path = str(resolved) if resolved else None
         except Exception as exc:
             logger.error("Could not resolve a SQLite path: %s", exc)
             return 2
+    if not db_path:
+        logger.error("SQLITE_DB_PATH is not set and could not be resolved.")
+        return 2
     config_loader = ConfigLoader(db_path=db_path)
 
     match_policy = config_loader.get_match_policy()

--- a/job-finder-worker/src/job_finder/scoring/engine.py
+++ b/job-finder-worker/src/job_finder/scoring/engine.py
@@ -74,11 +74,28 @@ class ScoreBreakdown:
     passed: bool = True
     rejection_reason: Optional[str] = None
 
+    @property
+    def freshness_points(self) -> int:
+        """Sum of freshness-category adjustments (positive when fresh, negative when stale)."""
+        return int(sum(adj.points for adj in self.adjustments if adj.category == "freshness"))
+
+    @property
+    def static_score(self) -> int:
+        """Score with the freshness component subtracted out.
+
+        The API recomputes freshness live from the listing's posted_date so an
+        aging job decays toward the staleScore without a periodic re-score job.
+        Persisting `static_score` lets the API do that math at read time.
+        """
+        return self.final_score - self.freshness_points
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
             "baseScore": self.base_score,
             "finalScore": self.final_score,
+            "staticScore": self.static_score,
+            "freshnessPoints": self.freshness_points,
             "adjustments": [adj.to_dict() for adj in self.adjustments],
             "passed": self.passed,
             "rejectionReason": self.rejection_reason,

--- a/job-finder-worker/src/job_finder/storage/job_storage.py
+++ b/job-finder-worker/src/job_finder/storage/job_storage.py
@@ -150,17 +150,18 @@ class JobStorage:
                 conn.execute(
                     """
                     INSERT INTO job_matches (
-                        id, job_listing_id, match_score,
+                        id, job_listing_id, match_score, static_score,
                         matched_skills, missing_skills, match_reasons, key_strengths,
                         potential_concerns, experience_match,
                         customization_recommendations, resume_intake_json, analyzed_at,
                         submitted_by, queue_item_id, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         job_id,
                         job_listing_id,
                         match_result.match_score,
+                        getattr(match_result, "static_score", None),
                         _serialize_list(match_result.matched_skills),
                         _serialize_list(match_result.missing_skills),
                         _serialize_list(match_reasons),

--- a/job-finder-worker/tests/scoring/test_engine.py
+++ b/job-finder-worker/tests/scoring/test_engine.py
@@ -211,6 +211,42 @@ class TestScoringEngine:
         assert isinstance(result.passed, bool)
         assert 0 <= result.final_score <= 100
 
+    def test_static_score_excludes_freshness_component(self, engine_factory):
+        """static_score = final_score - sum(freshness adjustments).
+
+        Verified by running the same extraction with and without a freshness
+        signal and checking the static_score matches.
+        """
+        engine = engine_factory()
+        fresh_extraction = JobExtractionResult(
+            work_arrangement="remote", days_old=1  # triggers freshScore
+        )
+        no_age_extraction = JobExtractionResult(work_arrangement="remote", days_old=None)
+
+        fresh_result = engine.score(fresh_extraction, "Engineer", "")
+        no_age_result = engine.score(no_age_extraction, "Engineer", "")
+
+        # Freshness adjustments must total to the freshScore from the config.
+        assert fresh_result.freshness_points == 10
+        # static_score should match the no-age run.
+        assert fresh_result.static_score == no_age_result.final_score
+
+    def test_freshness_points_is_zero_when_no_freshness_signal(self, engine_factory):
+        engine = engine_factory()
+        extraction = JobExtractionResult(work_arrangement="remote", days_old=None)
+        result = engine.score(extraction, "Engineer", "")
+        assert result.freshness_points == 0
+        assert result.static_score == result.final_score
+
+    def test_to_dict_includes_static_score_and_freshness_points(self, engine_factory):
+        engine = engine_factory()
+        result = engine.score(
+            JobExtractionResult(work_arrangement="remote", days_old=1), "Engineer", ""
+        )
+        payload = result.to_dict()
+        assert payload["staticScore"] == result.static_score
+        assert payload["freshnessPoints"] == result.freshness_points
+
     def test_parallel_skill_prevents_penalty(self, default_config, profile):
         """Parallel skills from taxonomy prevent missing penalty but don't give bonus.
 

--- a/shared/src/job.types.ts
+++ b/shared/src/job.types.ts
@@ -361,8 +361,14 @@ export interface JobMatch {
   /** Foreign key to job_listings table */
   jobListingId: string
 
-  /** AI match score (0-100) */
+  /** AI match score (0-100). When `staticScore` is present, the API replaces this
+   * with a freshness-adjusted score computed from the listing's age at read time. */
   matchScore: number
+
+  /** Match score with the freshness component removed. NULL for legacy rows
+   * scored before migration 070. The API computes live freshness from the
+   * listing's posted_date/created_at and adds it to this baseline. */
+  staticScore?: number | null
 
   /** Skills that match job requirements */
   matchedSkills: string[]


### PR DESCRIPTION
## Summary
Adds a live freshness adjustment to job match scores so an aging listing decays toward `staleScore` without a periodic re-score job.

- **shared/**: adds `staticScore` to the `JobMatch` contract.
- **worker** (`job-finder-worker`): scoring engine now computes a clamped `static_score` (baseline excluding age-based freshness) and exposes `freshness_points`. The repost penalty moves to its own `repost` category so the API does not subtract it during live recompute. New maintenance CLI `python -m job_finder.rescore_matches` re-applies the current match-policy + prefilter to existing rows; defaults to dry-run and now joins `companies` so company signals are scored. Streams candidates via `fetchmany()` and writes in batches to keep memory bounded.
- **API** (`job-finder-BE`): new `freshness-scorer.ts` recomputes the live adjustment per read using the listing's age. `listWithListings` now applies `minScore`/`maxScore` filters and `sortBy=score` ordering in memory against the live-adjusted score so the returned page is consistent with the filter.
- **infra**: migration `070_job_match_static_score.sql` adds `job_matches.static_score`.

## Testing
- [x] `npm run lint:server`
- [x] Workspace-specific unit tests (`pytest tests/scoring tests/ai`, `vitest run src/modules/job-matches`)
- [x] `npm run build:server` (via `tsc --noEmit`)

## Checklist
- [x] Added/updated docs, env samples, or SQL migrations if needed
- [x] Added/updated types in `shared/` if API/worker contracts changed
- [x] Confirmed no secrets or personal data are committed

## Additional Notes
Rollout: run `python -m job_finder.rescore_matches` (dry-run by default) before promoting, then `--apply` to backfill `static_score` for legacy rows. Rows without `static_score` fall back to the persisted `match_score`, so the new endpoint is safe before backfill.